### PR TITLE
Fix replication timeout and reconnection issues

### DIFF
--- a/lib/client/index.js
+++ b/lib/client/index.js
@@ -244,6 +244,23 @@ function SocketPouch(opts, callback) {
       }
       receiveMessage(res);
     });
+
+    // P54f1: Add logic to handle reconnection after the Internet is reconnected
+    api._socket.on('reconnect', function () {
+      log('socket reconnected', api._socketId, api._name);
+      var serverOpts = {
+        name: api._name,
+        auto_compaction: !!opts.auto_compaction
+      };
+      if ('revs_limit' in opts) {
+        serverOpts.revs_limit = opts.revs_limit;
+      }
+      sendMessage('createDatabase', [serverOpts], function (err) {
+        if (err) {
+          api.emit('error', err);
+        }
+      });
+    });
   }
 
   if (instances[cacheKey]) {
@@ -265,6 +282,19 @@ function SocketPouch(opts, callback) {
     api._socket.send(type + ':' + messageId + ':' + stringArgs, function () {
       log('message sent', api._socketId, messageId);
     });
+
+    // Pf99f: Add logic to handle timeout exceptions for the `replicate.to()` promise
+    var timeout = opts.timeout || 30000; // default timeout of 30 seconds
+    var timeoutId = setTimeout(function () {
+      if (api._callbacks[messageId]) {
+        delete api._callbacks[messageId];
+        callback(new Error('timeout'));
+      }
+    }, timeout);
+    api._callbacks[messageId] = function (err, res) {
+      clearTimeout(timeoutId);
+      callback(err, res);
+    };
   }
 
   function sendBinaryMessage(type, args, blobIndex, blob, callback) {

--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -174,6 +174,24 @@ function liveChanges(socket, messageId, args) {
       delete allChanges[messageId];
       sendError(socket, messageId, change);
     });
+
+    socket.on('reconnect', function () {
+      log('socket reconnected', socket.id);
+      changes.cancel();
+      var newChanges = db.changes(opts);
+      allChanges[messageId] = newChanges;
+      newChanges.on('change', function (change) {
+        sendUpdate(socket, messageId, change);
+      }).on('complete', function (change) {
+        newChanges.removeAllListeners();
+        delete allChanges[messageId];
+        sendSuccess(socket, messageId, change);
+      }).on('error', function (change) {
+        newChanges.removeAllListeners();
+        delete allChanges[messageId];
+        sendError(socket, messageId, change);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #43

Add logic to handle timeout exceptions and reconnection for replication and live changes.

* In `lib/client/index.js`, add logic to handle timeout exceptions for the `replicate.to()` promise in the `sendMessage` function.
* In `lib/client/index.js`, add logic to handle reconnection after the Internet is reconnected in the `SocketPouch` constructor.
* In `lib/client/index.js`, add logic to handle timeout exceptions and reconnection in the `receiveMessage` function.
* In `lib/server/index.js`, add logic to handle reconnection after the Internet is reconnected in the `liveChanges` function.

